### PR TITLE
Shorten the exception message show in the report

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,14 @@ Quick links:
 
 * Notes go here.
 
+## v1.1.2
+
+* Shorten the exception message show on the report.
+
+## v1.1.1
+
+* Fix could not find TLS ALPN provide.
+
 ## v1.1.0
 
 * Change GUI.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>vn.zalopay.benchmark</groupId>
     <artifactId>jmeter-grpc-request</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
@@ -12,6 +12,7 @@ import org.apache.jmeter.testelement.ThreadListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import vn.zalopay.benchmark.core.ClientCaller;
+import vn.zalopay.benchmark.exception.ShortExceptionName;
 
 public class GRPCSampler extends AbstractSampler implements ThreadListener {
 
@@ -124,7 +125,7 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
   private void errorResult(SampleResult res, Exception e) {
     res.sampleEnd();
     res.setSuccessful(false);
-    res.setResponseMessage("Exception: " + e.getCause());
+    res.setResponseMessage("Exception: " + ShortExceptionName.shortest(e.getCause().getMessage()));
     res.setResponseData(e.getMessage().getBytes());
     res.setDataType(SampleResult.TEXT);
     res.setResponseCode("500");

--- a/src/main/java/vn/zalopay/benchmark/exception/ShortExceptionName.java
+++ b/src/main/java/vn/zalopay/benchmark/exception/ShortExceptionName.java
@@ -1,0 +1,22 @@
+package vn.zalopay.benchmark.exception;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ShortExceptionName {
+
+  private static final List<String> list = Arrays.asList(
+      "DEADLINE_EXCEEDED"
+  );
+
+  public static String shortest(String exception) {
+
+    for (String shortName : list) {
+      if (exception.contains(shortName)) {
+        return shortName;
+      }
+    }
+
+    return exception;
+  }
+}


### PR DESCRIPTION
Shorten the DEADLINE_EXCEEDED exception shown in the report.

![image](https://user-images.githubusercontent.com/15891411/96155871-9fe46f80-0f3a-11eb-97f3-a735caf620e4.png)
