### PR TITLE
Move Metadata update to when Sample is tested

### DIFF
--- a/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
@@ -53,8 +53,7 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
                     getLibFolder(),
                     getFullMethod(),
                     isTls(),
-                    isTlsDisableVerification(),
-                    getMetadata());
+                    isTlsDisableVerification());
         }
     }
 
@@ -65,8 +64,9 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
         try {
             initGrpcClient();
             sampleResult.setSampleLabel(getName());
-            String grpcRequest = clientCaller.buildRequest(getRequestJson());
+            String grpcRequest = clientCaller.buildRequestAndMetadata(getRequestJson(),getMetadata());
             sampleResult.setSamplerData(grpcRequest);
+            sampleResult.setRequestHeaders(clientCaller.getMetadataString());
             sampleResult.sampleStart();
             grpcResponse = clientCaller.call(getDeadline());
             sampleResult.sampleEnd();

--- a/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class ClientCaller {
     private Descriptors.MethodDescriptor methodDescriptor;
@@ -42,16 +43,16 @@ public class ClientCaller {
     private boolean disableTtlVerification;
     ChannelFactory channelFactory;
 
-    public ClientCaller(String HOST_PORT, String TEST_PROTO_FILES, String LIB_FOLDER, String FULL_METHOD, boolean TLS, boolean TLS_DISABLE_VERIFICATION, String METADATA) {
-        this.init(HOST_PORT, TEST_PROTO_FILES, LIB_FOLDER, FULL_METHOD, TLS, TLS_DISABLE_VERIFICATION, METADATA);
+    public ClientCaller(String HOST_PORT, String TEST_PROTO_FILES, String LIB_FOLDER, String FULL_METHOD, boolean TLS, boolean TLS_DISABLE_VERIFICATION) {
+        this.init(HOST_PORT, TEST_PROTO_FILES, LIB_FOLDER, FULL_METHOD, TLS, TLS_DISABLE_VERIFICATION);
     }
 
-    private void init(String HOST_PORT, String TEST_PROTO_FILES, String LIB_FOLDER, String FULL_METHOD, boolean TLS, boolean TLS_DISABLE_VERIFICATION, String METADATA) {
+    private void init(String HOST_PORT, String TEST_PROTO_FILES, String LIB_FOLDER, String FULL_METHOD, boolean TLS, boolean TLS_DISABLE_VERIFICATION) {
         try {
             tls = TLS;
             disableTtlVerification = TLS_DISABLE_VERIFICATION;
             hostAndPort = HostAndPort.fromString(HOST_PORT);
-            metadataMap = buildHashMetadata(METADATA);
+            metadataMap = new LinkedHashMap<>();
             channelFactory = ChannelFactory.create();
             ProtoMethodName grpcMethodName =
                     ProtoMethodName.parseFullGrpcMethodName(FULL_METHOD);
@@ -131,10 +132,15 @@ public class ClientCaller {
         return channel.isTerminated();
     }
 
-    public String buildRequest(String jsonData) {
+    public String buildRequestAndMetadata(String jsonData, String metadata) {
         try {
+            metadataMap.clear();
+            metadataMap.putAll(buildHashMetadata(metadata));
             requestMessages = Reader.create(methodDescriptor.getInputType(), jsonData, registry).read();
             return JsonFormat.printer().includingDefaultValueFields().print(requestMessages.get(0));
+        } catch (IllegalArgumentException e) {
+            shutdownNettyChannel();
+            throw e;
         } catch (Exception e) {
             shutdownNettyChannel();
             throw new RuntimeException("Caught exception while parsing request for rpc", e);
@@ -218,5 +224,12 @@ public class ClientCaller {
         } catch (Exception e) {
             throw new RuntimeException("Caught exception while parsing deadline to long", e);
         }
+    }
+
+    public String getMetadataString() {
+        return metadataMap.entrySet()
+                .stream()
+                .map(e -> e.getKey() + ": " + e.getValue())
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/src/test/java/vn/zalopay/benchmark/core/client/ClientCallerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/client/ClientCallerTest.java
@@ -27,8 +27,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanSendGrpcUnaryRequest() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1:1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1:1,key2:2");
         GrpcResponse resp = clientCaller.call("5000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -37,16 +37,16 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanGetShutDownBoolean() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1:1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1:1,key2:2");
         Assert.assertEquals(clientCaller.isShutdown(), false);
         Assert.assertEquals(clientCaller.isTerminated(), false);
     }
 
     @Test
     public void testCanGetShutDownBooleanAfterShutdown() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1:1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1:1,key2:2");
         clientCaller.shutdownNettyChannel();
         Assert.assertEquals(clientCaller.isShutdown(), true);
         Assert.assertEquals(clientCaller.isTerminated(), true);
@@ -54,8 +54,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanCallClientStreamingRequest() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1:1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1:1,key2:2");
         GrpcResponse resp = clientCaller.callClientStreaming("5000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -64,8 +64,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanCallServerStreamingRequest() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1:1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1:1,key2:2");
         GrpcResponse resp = clientCaller.callServerStreaming("5000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -74,8 +74,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanCallBidiStreamingRequest() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1:1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1:1,key2:2");
         GrpcResponse resp = clientCaller.callBidiStreaming("5000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -84,8 +84,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanSendRequestWithNegativeTimeoutRequest() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("-10");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -94,8 +94,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Metadata entry must be valid JSON String or in key1:value1,key2:value2 format if not JsonString but found: key1=1,key2:2")
     public void testCanThrowExceptionWithInvalidMetaData() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "key1=1,key2:2");
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "key1=1,key2:2");
         GrpcResponse resp = clientCaller.call("2000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -104,8 +104,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanSendGrpcUnaryRequestWithMetaData() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("2000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -114,8 +114,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanSendGrpcUnaryRequestWithEncodedMetaData() throws UnsupportedEncodingException {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, "tracestate:" + URLEncoder.encode("a=3,b:4", StandardCharsets.UTF_8.name()));
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, "tracestate:" + URLEncoder.encode("a=3,b:4", StandardCharsets.UTF_8.name()));
         GrpcResponse resp = clientCaller.call("2000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -124,8 +124,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanSendGrpcUnaryRequestWithSSLAndDisableSSLVerification() {
-        clientCaller = new ClientCaller(HOST_PORT_TLS, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, true, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT_TLS, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, true);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -134,8 +134,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test
     public void testCanSendGrpcUnaryRequestWithSSLAndEnableSSLVerification() {
-        clientCaller = new ClientCaller(HOST_PORT_TLS, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT_TLS, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10000");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -144,36 +144,36 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while parsing deadline to long")
     public void testThrowExceptionWithInvalidTimeoutFormat() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         clientCaller.call("1000s");
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while parsing deadline to long")
     public void testThrowExceptionWithBlankTimeoutFormat() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         clientCaller.call(" ");
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while parsing deadline to long")
     public void testThrowExceptionWithEmptyTimeoutFormat() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         clientCaller.call("");
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while parsing deadline to long")
     public void testThrowExceptionWithNullTimeoutFormat() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         clientCaller.call(null);
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while parsing request for rpc")
     public void testThrowExceptionWithInvalidRequestJson() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest("{shelf:{\"id\":1599156420811,\"theme\":\"Hello server!!\".}}");
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata("{shelf:{\"id\":1599156420811,\"theme\":\"Hello server!!\".}}", METADATA);
         clientCaller.call("1000");
     }
 
@@ -181,8 +181,8 @@ public class ClientCallerTest extends BaseTest {
     public void testThrowExceptionWithParsingRequestToJson() {
         MockedStatic<com.google.protobuf.util.JsonFormat> jsonFormat = Mockito.mockStatic(com.google.protobuf.util.JsonFormat.class);
         jsonFormat.when(JsonFormat::printer).then((i) -> new InvalidProtocolBufferException("Dummy Exception"));
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest("{shelf:{\"id\":1599156420811,\"theme\":\"Hello server!!\".}}");
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata("{shelf:{\"id\":1599156420811,\"theme\":\"Hello server!!\".}}", METADATA);
         clientCaller.call("1000");
     }
 
@@ -190,7 +190,7 @@ public class ClientCallerTest extends BaseTest {
     public void testThrowExceptionWithExceptionInProtocInvoke() {
         MockedStatic<ProtocInvoker> protocInvoker = Mockito.mockStatic(ProtocInvoker.class);
         protocInvoker.when(() -> ProtocInvoker.forConfig(Mockito.anyString(), Mockito.anyString()).invoke()).thenThrow(new RuntimeException("Dummy Exception"));
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Error in create SSL connection!")
@@ -204,7 +204,7 @@ public class ClientCallerTest extends BaseTest {
                     return sslContext;
                 }
         );
-        clientCaller = new ClientCaller("localhost:1231", PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, false, METADATA);
+        clientCaller = new ClientCaller("localhost:1231", PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, false);
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Error in create SSL connection!")
@@ -218,13 +218,13 @@ public class ClientCallerTest extends BaseTest {
                     return sslContext;
                 }
         );
-        clientCaller = new ClientCaller("localhost:1231", PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, true, METADATA);
+        clientCaller = new ClientCaller("localhost:1231", PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, true, true);
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")
     public void testThrowExceptionWithTimeoutRequest() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), FULL_METHOD, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("1");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -233,8 +233,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")
     public void testThrowExceptionWithTimeoutRequestServerStream() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/GetShelfStreamServer", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/GetShelfStreamServer", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.callServerStreaming("1");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -243,8 +243,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")
     public void testThrowExceptionWithTimeoutRequestClientStream() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/GetShelfStreamClient", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/GetShelfStreamClient", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.callClientStreaming("1");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -253,8 +253,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")
     public void testThrowExceptionWithTimeoutRequestBidiStream() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/GetShelfStreamBidi", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/GetShelfStreamBidi", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.callBidiStreaming("1");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -263,20 +263,20 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Unable to find method invalidName in service Bookstore")
     public void testThrowExceptionWithInvalidMethodName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/invalidName", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/invalidName", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "fullMethodName")
     public void testThrowExceptionWithNullMethodName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), null, false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), null, false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Could not extract full service from  ")
     public void testThrowExceptionWithBlankMethodName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), " ", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), " ", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -285,8 +285,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Could not extract full service from ")
     public void testThrowExceptionWithEmptyMethodName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -295,8 +295,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Could not extract package name from bookstoreBookstore")
     public void testThrowExceptionWithPackageAndServiceMethodName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstoreBookstore/CreateShelf", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstoreBookstore/CreateShelf", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -305,8 +305,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Could not extract service from bookstoreBookstore.")
     public void testThrowExceptionWithInvalidPackagedName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstoreBookstore./CreateShelf", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstoreBookstore./CreateShelf", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -315,8 +315,8 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Could not extract method name from bookstore.Bookstore/")
     public void testThrowExceptionWithInvalidMethodNameWithDoubleSlash() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstore/", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("10");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
@@ -325,7 +325,7 @@ public class ClientCallerTest extends BaseTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Unable to find service with name: Bookstores")
     public void testThrowExceptionWithInvalidServiceName() {
-        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstores/CreateShelf", false, false, METADATA);
-        clientCaller.buildRequest(REQUEST_JSON);
+        clientCaller = new ClientCaller(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(), "bookstore.Bookstores/CreateShelf", false, false);
+        clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
     }
 }


### PR DESCRIPTION
This change allows to use variables for metadata and picks up variable change between thread iterations (if more than one loop is specified in ThreadGroup