### PR TITLE
Let Proto root directory fully support '${}' to refer to user variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <guava.version>30.1.1-jre</guava.version>
         <lombok.version>1.18.10</lombok.version>
-        <jmeter.core.version>5.4.1</jmeter.core.version>
+        <jmeter.version>4.0</jmeter.version>
+        <jmeter.test.version>5.4.1</jmeter.test.version>
         <netty.version>4.1.65.Final</netty.version>
         <netty.ssl.version>2.0.39.Final</netty.ssl.version>
         <slf4j.version>1.7.26</slf4j.version>
@@ -36,11 +38,10 @@
             <artifactId>jmeter-plugins-cmn-jmeter</artifactId>
             <version>${cmn.jmeter.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_core</artifactId>
-            <version>4.0</version>
+            <version>${jmeter.version}</version>
         </dependency>
 
         <dependency>
@@ -131,7 +132,7 @@
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_components</artifactId>
-            <version>${jmeter.core.version}</version>
+            <version>${jmeter.test.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/vn/zalopay/benchmark/GRPCSamplerGui.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSamplerGui.java
@@ -34,7 +34,7 @@ public class GRPCSamplerGui extends AbstractSamplerGui {
 
     private static final Logger log = LoggerFactory.getLogger(GRPCSamplerGui.class);
     private static final long serialVersionUID = 240L;
-    private static final String WIKIPAGE = "GRPCSampler";
+    private static final String WIKIPAGE = "https://github.com/zalopay-oss/jmeter-grpc-request";
 
     private JTextField protoFolderField;
     private JButton protoBrowseButton;

--- a/src/main/java/vn/zalopay/benchmark/core/ClientList.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientList.java
@@ -7,19 +7,44 @@ import com.google.protobuf.Descriptors.ServiceDescriptor;
 import vn.zalopay.benchmark.core.protobuf.ProtocInvoker;
 import vn.zalopay.benchmark.core.protobuf.ServiceResolver;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class ClientList {
 
+    private static final Map<String, ServiceResolver> serviceResolverMap = new HashMap<>();
+
     public static ServiceResolver getServiceResolver(String protoFile, String libFolder) {
+        return getServiceResolver(protoFile, libFolder, false);
+    }
+
+    /**
+     * Get Proto File ServiceResolver
+     *
+     * @param protoFile proto file root path
+     * @param libFolder lib file path
+     * @param reload    reload not cache
+     * @return proto file resolver
+     */
+    public static ServiceResolver getServiceResolver(String protoFile, String libFolder, boolean reload) {
         try {
+            String serviceResolverKey = protoFile + libFolder;
+            if (reload == false) {
+                ServiceResolver serviceResolver = serviceResolverMap.get(serviceResolverKey);
+                if (serviceResolver != null) {
+                    return serviceResolver;
+                }
+            }
+
             if (!Strings.isNullOrEmpty(protoFile)) {
                 final DescriptorProtos.FileDescriptorSet fileDescriptorSet;
                 ProtocInvoker invoker = ProtocInvoker.forConfig(protoFile, libFolder);
                 fileDescriptorSet = invoker.invoke();
 
                 ServiceResolver serviceResolver = ServiceResolver.fromFileDescriptorSet(fileDescriptorSet);
+                serviceResolverMap.put(serviceResolverKey, serviceResolver);
                 return serviceResolver;
             }
         } catch (Throwable t) {

--- a/src/main/java/vn/zalopay/benchmark/core/ClientList.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientList.java
@@ -66,7 +66,7 @@ public class ClientList {
     }
 
     public static List<String> listServices(String protoFile, String libFolder) {
-        return listServices(getServiceResolver(protoFile, libFolder));
+        return listServices(getServiceResolver(protoFile, libFolder, true));
     }
 
 }

--- a/src/main/java/vn/zalopay/benchmark/util/JMeterVariableUtils.java
+++ b/src/main/java/vn/zalopay/benchmark/util/JMeterVariableUtils.java
@@ -1,0 +1,65 @@
+package vn.zalopay.benchmark.util;
+
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.engine.util.ValueReplacer;
+import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.JMeterGUIComponent;
+import org.apache.jmeter.testelement.TestElement;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * JMeter user variable load util.
+ * Realize that user variables can be easily used when operating in Gui or when the Test Plan is not running.
+ *
+ * @author ylyue
+ * @since 2021/12/20
+ */
+public class JMeterVariableUtils {
+
+    /**
+     * Gets the value of a private member variable.
+     */
+    public static Object getPrivateField(Object instance, String filedName) throws NoSuchFieldException, IllegalAccessException {
+        Field field = instance.getClass().getDeclaredField(filedName);
+        field.setAccessible(true);
+        return field.get(instance);
+    }
+
+    /**
+     * Get a ValueReplacer for the test tree.
+     *
+     * @return a ValueReplacer configured for the test tree
+     */
+    public static ValueReplacer getReplacer() {
+        ValueReplacer replacer = GuiPackage.getInstance().getReplacer();
+        try {
+            Map<TestElement, JMeterGUIComponent> nodesToGui = (Map<TestElement, JMeterGUIComponent>) getPrivateField(GuiPackage.getInstance(), "nodesToGui");
+            nodesToGui.forEach((key, value) -> {
+                if (key instanceof Arguments) {
+                    replacer.addVariables(((Arguments) key).getArgumentsAsMap());
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return replacer;
+    }
+
+    /**
+     * Replaces ${key} by value extracted from
+     * {@link org.apache.jmeter.threads.JMeterVariables JMeterVariables} if any
+     *
+     * @param el {@link TestElement} in which values should be replaced
+     */
+    public static void undoVariableReplacement(TestElement el) {
+        try {
+            getReplacer().undoReverseReplace(el);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/vn/zalopay/benchmark/util/JMeterVariableUtils.java
+++ b/src/main/java/vn/zalopay/benchmark/util/JMeterVariableUtils.java
@@ -33,9 +33,14 @@ public class JMeterVariableUtils {
      * @return a ValueReplacer configured for the test tree
      */
     public static ValueReplacer getReplacer() {
-        ValueReplacer replacer = GuiPackage.getInstance().getReplacer();
+        GuiPackage guiPackage = GuiPackage.getInstance();
+        if (guiPackage == null) {
+            return new ValueReplacer();
+        }
+
+        ValueReplacer replacer = guiPackage.getReplacer();
         try {
-            Map<TestElement, JMeterGUIComponent> nodesToGui = (Map<TestElement, JMeterGUIComponent>) getPrivateField(GuiPackage.getInstance(), "nodesToGui");
+            Map<TestElement, JMeterGUIComponent> nodesToGui = (Map<TestElement, JMeterGUIComponent>) getPrivateField(guiPackage, "nodesToGui");
             nodesToGui.forEach((key, value) -> {
                 if (key instanceof Arguments) {
                     replacer.addVariables(((Arguments) key).getArgumentsAsMap());


### PR DESCRIPTION
pr features:
- Fix helpPage address, (① Old address is invalid, new address points to Github)
- add getServiceResolver cache
- New JMeterVariableUtils for manipulating user variables in GUI
- Proto root directory already supports the user variable '${}' (②③ Clicking the Listing button in the gui will throw an exception of `Unable to resolve service by invoking protoc`, because the user variables are not loaded at this time.)

![image](https://user-images.githubusercontent.com/39790401/147058127-9d4518c7-3e69-4a16-8fb6-e5b3b693868b.png)