### PR TITLE
Solve `CreateProcess Error = 206`, and slimming plug-in volume

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,18 +14,13 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <guava.version>30.1.1-jre</guava.version>
         <lombok.version>1.18.10</lombok.version>
         <jmeter.version>4.0</jmeter.version>
         <jmeter.test.version>5.4.1</jmeter.test.version>
-        <netty.version>4.1.65.Final</netty.version>
         <netty.ssl.version>2.0.39.Final</netty.ssl.version>
-        <slf4j.version>1.7.26</slf4j.version>
-        <junit.version>4.13.2</junit.version>
         <os72.protoc.version>3.11.4</os72.protoc.version>
         <grpc.version>1.38.0</grpc.version>
         <protobuf.version>3.17.1</protobuf.version>
-        <jcommander.version>1.48</jcommander.version>
         <cmn.jmeter.version>0.6</cmn.jmeter.version>
         <emulators.jmeter.version>0.4</emulators.jmeter.version>
         <mockito.version>3.10.0</mockito.version>
@@ -82,6 +77,12 @@
 
         <!-- test -->
         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_components</artifactId>
             <version>${jmeter.test.version}</version>
@@ -94,9 +95,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.ssl.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -151,14 +152,14 @@
                             <artifactSet>
                                 <includes>
                                     <include>io.grpc</include>
-                                    <include>com.google.guava</include>
+                                    <include>io.netty</include>
                                     <include>io.perfmark</include>
                                     <include>com.google.protobuf</include>
-                                    <include>io.netty</include>
+                                    <include>com.google.guava</include>
                                     <include>com.google.code.gson</include>
                                     <include>com.github.os72</include>
-                                    <include>kg.apc</include>
                                     <include>com.alibaba</include>
+                                    <include>kg.apc</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -30,102 +30,54 @@
         <emulators.jmeter.version>0.4</emulators.jmeter.version>
         <mockito.version>3.10.0</mockito.version>
         <testng.version>7.4.0</testng.version>
+        <fastjson.version>1.2.76</fastjson.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>kg.apc</groupId>
-            <artifactId>jmeter-plugins-cmn-jmeter</artifactId>
-            <version>${cmn.jmeter.version}</version>
-        </dependency>
+        <!-- jmeter-plugins -->
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_core</artifactId>
             <version>${jmeter.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>com.github.os72</groupId>
-            <artifactId>protoc-jar-maven-plugin</artifactId>
-            <version>${os72.protoc.version}</version>
+            <groupId>kg.apc</groupId>
+            <artifactId>jmeter-plugins-cmn-jmeter</artifactId>
+            <version>${cmn.jmeter.version}</version>
         </dependency>
 
+        <!-- proto -->
+        <dependency>
+            <groupId>com.github.os72</groupId>
+            <artifactId>protoc-jar</artifactId>
+            <version>${os72.protoc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
             <version>${protobuf.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-all</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-services</artifactId>
-            <version>${grpc.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty.ssl.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
-        </dependency>
-
+        <!-- json -->
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.76</version>
+            <version>${fastjson.version}</version>
         </dependency>
 
         <!-- test -->
@@ -187,6 +139,15 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>com.github.os72:protoc-jar</artifact>
+                                    <excludes>
+                                        <exclude>bin/2.4.1/**</exclude>
+                                        <exclude>bin/2.5.0/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes>
                                     <include>io.grpc</include>
@@ -194,7 +155,6 @@
                                     <include>io.perfmark</include>
                                     <include>com.google.protobuf</include>
                                     <include>io.netty</include>
-                                    <include>com.fasterxml.jackson.core</include>
                                     <include>com.google.code.gson</include>
                                     <include>com.github.os72</include>
                                     <include>kg.apc</include>

--- a/src/main/java/vn/zalopay/benchmark/GRPCSamplerGui.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSamplerGui.java
@@ -323,8 +323,6 @@ public class GRPCSamplerGui extends AbstractSamplerGui {
         }
     }
 
-
-
     private void requestMock() {
         try {
             if (StringUtils.isNotBlank(requestJsonArea.getText())) {
@@ -332,6 +330,7 @@ public class GRPCSamplerGui extends AbstractSamplerGui {
             }
             String fullMethod = fullMethodField.getSelectedItem().toString();
             ProtoMethodName grpcMethodName = ProtoMethodName.parseFullGrpcMethodName(fullMethod);
+            JMeterVariableUtils.undoVariableReplacement(grpcSampler);
             ServiceResolver serviceResolver = ClientList.getServiceResolver(grpcSampler.getProtoFolder(), grpcSampler.getLibFolder());
             Descriptors.MethodDescriptor methodDescriptor = serviceResolver.resolveServiceMethod(grpcMethodName);
             if (methodDescriptor != null) {

--- a/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
@@ -1,7 +1,6 @@
 package vn.zalopay.benchmark.core;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.alibaba.fastjson.JSONObject;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -85,17 +84,17 @@ public class ClientCaller {
     private Map<String, String> buildHashMetadata(String metadata) {
         Map<String, String> metadataHash = new LinkedHashMap<>();
 
-        if (Strings.isNullOrEmpty(metadata))
+        if (Strings.isNullOrEmpty(metadata)) {
             return metadataHash;
+        }
 
         if (metadata.startsWith("{") && metadata.endsWith("}")) {
-            ObjectMapper mapper = new ObjectMapper();
             try {
-                Map<String, Object> map = mapper.readValue(metadata, Map.class);
+                Map<String, Object> map = JSONObject.parseObject(metadata);
                 for (Map.Entry<String, Object> entry : map.entrySet()) {
                     metadataHash.put(entry.getKey(), (String)entry.getValue());
                 }
-            } catch (JsonProcessingException e) {
+            } catch (Exception e) {
                 Preconditions.checkArgument(1 == 2,
                         "Metadata entry must be valid JSON String or in key1:value1,key2:value2 format if not JsonString but found: " + metadata);
             }

--- a/src/main/java/vn/zalopay/benchmark/core/ClientList.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientList.java
@@ -1,9 +1,9 @@
 package vn.zalopay.benchmark.core;
 
-import com.google.common.base.Strings;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
+import org.apache.commons.lang3.StringUtils;
 import vn.zalopay.benchmark.core.protobuf.ProtocInvoker;
 import vn.zalopay.benchmark.core.protobuf.ServiceResolver;
 
@@ -38,7 +38,7 @@ public class ClientList {
                 }
             }
 
-            if (!Strings.isNullOrEmpty(protoFile)) {
+            if (StringUtils.isNotBlank(protoFile)) {
                 final DescriptorProtos.FileDescriptorSet fileDescriptorSet;
                 ProtocInvoker invoker = ProtocInvoker.forConfig(protoFile, libFolder);
                 fileDescriptorSet = invoker.invoke();

--- a/src/test/java/vn/zalopay/benchmark/core/client/ClientListTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/client/ClientListTest.java
@@ -1,7 +1,6 @@
 package vn.zalopay.benchmark.core.client;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.apache.commons.io.FileUtils;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -9,7 +8,6 @@ import org.testng.annotations.Test;
 import vn.zalopay.benchmark.core.BaseTest;
 import vn.zalopay.benchmark.core.ClientList;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.CopyOption;
 import java.nio.file.FileSystems;


### PR DESCRIPTION
## features
- Fix the bug that protoc does not support parsing of large folders, and solve CreateProcess error=206 #86 
- Standard engineering dependence, slimming `jmeter-grpc-request.jar` plug-in (from the original 46M to the current **16M**)

## Some promotion ideas
Maybe we should consider releasing the official package of `v1.1.2` or `v1.2`, publish it to github releases instead of the `dist/bin` folder, and also need to synchronize to the JMeter plugin library

This will facilitate the promotion of the `jmeter-grpc-request` plugin in the open source community.