### PR TITLE
fix: Type Registry required when printing Json

### DIFF
--- a/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
@@ -136,7 +136,7 @@ public class ClientCaller {
             metadataMap.clear();
             metadataMap.putAll(buildHashMetadata(metadata));
             requestMessages = Reader.create(methodDescriptor.getInputType(), jsonData, registry).read();
-            return JsonFormat.printer().includingDefaultValueFields().print(requestMessages.get(0));
+            return JsonFormat.printer().includingDefaultValueFields().usingTypeRegistry(registry).print(requestMessages.get(0));
         } catch (IllegalArgumentException e) {
             shutdownNettyChannel();
             throw e;


### PR DESCRIPTION
Type registry required to recognize "well-known types" and properly work with protobuf.Any type.