### PR TITLE
More friendly exception prompt

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  range: 80..90
+  round: down
+  precision: 2
+  status:
+    project:
+      default:
+        target: 85%
+        threshold: 5%
+        informational: true
+    patch:
+      default:
+        target: 85%
+        threshold: 5%
+        if_ci_failed: error
+        informational: true
+comment:
+  layout: reach, diff, flags, files
+  behavior: default
+  require_changes: false
+github_checks:
+  annotations: false

--- a/dist/benchmark/grpc-server/src/main/resources/protos-error/invalid.proto
+++ b/dist/benchmark/grpc-server/src/main/resources/protos-error/invalid.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package bookstore;
+
+option java_multiple_files = true;
+option java_outer_classname = "BookstoreProto";
+option java_package = "generated.com.google.endpoints.examples.bookstore";
+
+import "google/api/annotations.proto";
+import "google/protobuf/empty.proto";
+import "invalid.proto";
+
+// A simple Bookstore API.
+//
+// The API manages shelves and books resources. Shelves contain books.
+service Invalid {
+  // Returns a list of all shelves in the bookstore.
+  rpc ListShelves (google.protobuf.Empty) returns (ListShelvesResponse) {
+    // Define HTTP mapping.
+    // Client example (Assuming your service is hosted at the given 'DOMAIN_NAME'):
+    //   curl http://DOMAIN_NAME/v1/shelves
+    option (google.api.http) = { get: "/v1/shelves" };
+  }
+  // Creates a new shelf in the bookstore.
+  rpc CreateShelf (CreateShelfRequest) returns (Shelf) {
+    // Client example:
+    //   curl -d '{"theme":"Music"}' http://DOMAIN_NAME/v1/shelves
+    option (google.api.http) = {
+      post: "/v1/shelves"
+      body: "shelf"
+    };
+  }
+
+  rpc GetShelfStreamClient (stream CreateShelfRequest) returns (ListShelvesResponse);
+  rpc GetShelfStreamServer (CreateShelfRequest) returns (stream Shelf);
+  rpc GetShelfStreamBidi (stream CreateShelfRequest) returns (stream Shelf);
+}
+
+// Response to ListShelves call.
+message ListShelvesResponse {
+  // Shelves in the bookstore.
+  repeated Shelf shelves = 1;
+}
+
+// Request message for CreateShelf method.
+message CreateShelfRequest {
+  // The shelf resource to create.
+  Shelf shelf = 1;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,11 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jmeter.version>4.0</jmeter.version>
-        <jmeter.test.version>5.4.1</jmeter.test.version>
         <netty.ssl.version>2.0.39.Final</netty.ssl.version>
         <os72.protoc.version>3.11.4</os72.protoc.version>
         <grpc.version>1.38.0</grpc.version>
         <protobuf.version>3.17.1</protobuf.version>
-        <cmn.jmeter.version>0.6</cmn.jmeter.version>
+        <jmeter.cmn.version>0.6</jmeter.cmn.version>
         <emulators.jmeter.version>0.4</emulators.jmeter.version>
         <mockito.version>3.10.0</mockito.version>
         <testng.version>7.4.0</testng.version>
@@ -37,7 +36,7 @@
         <dependency>
             <groupId>kg.apc</groupId>
             <artifactId>jmeter-plugins-cmn-jmeter</artifactId>
-            <version>${cmn.jmeter.version}</version>
+            <version>${jmeter.cmn.version}</version>
         </dependency>
 
         <!-- proto -->
@@ -84,7 +83,7 @@
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_components</artifactId>
-            <version>${jmeter.test.version}</version>
+            <version>${jmeter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -94,15 +93,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty.ssl.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.ssl.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <lombok.version>1.18.10</lombok.version>
         <jmeter.version>4.0</jmeter.version>
         <jmeter.test.version>5.4.1</jmeter.test.version>
         <netty.ssl.version>2.0.39.Final</netty.ssl.version>

--- a/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
@@ -113,7 +113,7 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
                 responseMessage += code.value() + " " + code.name();
                 responseData += code.value() + " " + throwable.getMessage();
             } else {
-                responseMessage = ExceptionUtils.getPrintExceptionToStr(throwable, 0);
+                responseMessage += ExceptionUtils.getPrintExceptionToStr(throwable, 0);
                 responseData = responseMessage;
             }
 

--- a/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
@@ -1,5 +1,6 @@
 package vn.zalopay.benchmark;
 
+import jodd.exception.ExceptionUtil;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
@@ -9,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import vn.zalopay.benchmark.core.ClientCaller;
 import vn.zalopay.benchmark.core.config.GrpcRequestConfig;
 import vn.zalopay.benchmark.core.specification.GrpcResponse;
+import vn.zalopay.benchmark.util.ExceptionUtils;
 
 import java.nio.charset.StandardCharsets;
 
@@ -45,12 +47,11 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
 
     private void trace(String s) {
         String threadName = Thread.currentThread().getName();
-        log.debug("{} ({}) {} {}", threadName,
-                getTitle(), s, this.toString());
+        log.debug("{} ({}) {} {}", threadName, getTitle(), s, this);
     }
 
     private void initGrpcConfigRequest() {
-        if (grpcRequestConfig == null)
+        if (grpcRequestConfig == null) {
             grpcRequestConfig = new GrpcRequestConfig(
                     getHostPort(),
                     getProtoFolder(),
@@ -60,6 +61,7 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
                     isTlsDisableVerification(),
                     getChannelShutdownAwaitTime()
             );
+        }
     }
 
     private void initGrpcClient() {
@@ -70,37 +72,41 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
 
     @Override
     public SampleResult sample(Entry ignored) {
-        GrpcResponse grpcResponse = new GrpcResponse();
         SampleResult sampleResult = new SampleResult();
 
-        // Console prints unknown exceptions - Intercepts unknown exceptions and sends them to the console to print instead of throwing the results into the GRPC response.
+        // Intercepts exceptions before GRPC requests are initiated
         try {
+            sampleResult.setSampleLabel(getName());
             initGrpcConfigRequest();
             initGrpcClient();
-            sampleResult.setSampleLabel(getName());
             String grpcRequest = clientCaller.buildRequestAndMetadata(getRequestJson(), getMetadata());
             sampleResult.setSamplerData(grpcRequest);
             sampleResult.setRequestHeaders(clientCaller.getMetadataString());
             sampleResult.sampleStart();
         } catch (Exception e) {
-            log.error("An unknown error occurred before the GRPC request was initiated, and the stack trace is as follows: ", e);
-            startSamplerToStopIfCatchException(sampleResult);
-            generateErrorResultInInitGRPCRequest(sampleResult, e);
+            sampleResult.setSuccessful(false);
+            sampleResult.setResponseCode("400");
+            sampleResult.setDataType(SampleResult.TEXT);
+            sampleResult.setResponseMessage(" GRPCSampler parsing exception: An unknown exception occurred before the GRPC request was initiated, See response body for the stack trace.");
+            sampleResult.setResponseData(ExceptionUtils.getPrintExceptionToStr(e, null), "UTF-8");
             return sampleResult;
         }
 
         // Initiate a GRPC request
-        try {
-            grpcResponse = clientCaller.call(getDeadline());
-            sampleResult.sampleEnd();
+        GrpcResponse grpcResponse = clientCaller.call(getDeadline());
+        sampleResult.sampleEnd();
+        sampleResult.setDataType(SampleResult.TEXT);
+        if (grpcResponse.isSuccess()) {
             sampleResult.setSuccessful(true);
             sampleResult.setResponseCodeOK();
             sampleResult.setResponseMessage("Success");
-            sampleResult.setDataType(SampleResult.TEXT);
             sampleResult.setResponseData(grpcResponse.getGrpcMessageString().getBytes(StandardCharsets.UTF_8));
-        } catch (RuntimeException e) {
-            startSamplerToStopIfCatchException(sampleResult);
-            generateErrorResult(grpcResponse, sampleResult, e);
+        } else {
+            Throwable throwable = grpcResponse.getThrowable();
+            sampleResult.setSuccessful(false);
+            sampleResult.setResponseCode("500");
+            sampleResult.setResponseMessage(" " + ExceptionUtils.getPrintExceptionToStr(throwable, 0));
+            sampleResult.setResponseData(ExceptionUtils.getPrintExceptionToStr(throwable, null), "UTF-8");
         }
 
         return sampleResult;
@@ -135,37 +141,6 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
                 Integer.toHexString(hashCode()) +
                 "-" +
                 getName();
-    }
-
-    private void generateErrorResultInInitGRPCRequest(SampleResult sampleResult, Exception e) {
-        String msg = String.format("GRPCSampler Exception: An unknown exception occurred before the GRPC " +
-                "request was initiated. %s", e.getCause().getMessage());
-        sampleResult.setSampleLabel("Error When Initiated gRPC");
-        sampleResult.setSuccessful(false);
-        sampleResult.setResponseCode("500");
-        sampleResult.setDataType(SampleResult.TEXT);
-        sampleResult.setResponseData(msg.getBytes(StandardCharsets.UTF_8));
-        sampleResult.setResponseMessage(msg);
-    }
-
-    private void generateErrorResult(GrpcResponse grpcResponse, SampleResult sampleResult, Exception e) {
-        try {
-            sampleResult.setSuccessful(false);
-            sampleResult.setResponseCode("500");
-            sampleResult.setDataType(SampleResult.TEXT);
-            sampleResult.sampleEnd();
-            sampleResult.setResponseMessage("Exception: " + e.getCause().getMessage());
-            sampleResult.setResponseData(String.format("Exception: %s. %s", e.getCause().getMessage(), grpcResponse.getGrpcMessageString()), "UTF-8");
-        } catch (Exception ex) {
-            // Prints exceptions that occur before the request is initiated
-            e.printStackTrace();
-            log.error("GrpcMessage: {}", grpcResponse.getGrpcMessageString());
-        }
-    }
-
-    private void startSamplerToStopIfCatchException(SampleResult sampleResult) {
-        if (sampleResult.getStartTime() == 0L)
-            sampleResult.sampleStart();
     }
 
     /**
@@ -259,8 +234,8 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
         setProperty(CHANNEL_SHUTDOWN_AWAIT_TIME, awaitShutdownTime);
     }
 
-
     private String getHostPort() {
         return getHost() + ":" + getPort();
     }
+
 }

--- a/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
@@ -107,11 +107,12 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
             sampleResult.setSuccessful(false);
             sampleResult.setResponseCode(" 500");
             String responseMessage = " ";
-            String responseData = " ";
+            String responseData = "";
             if (throwable instanceof StatusRuntimeException) {
-                Status.Code code = ((StatusRuntimeException) throwable).getStatus().getCode();
+                Status status = ((StatusRuntimeException) throwable).getStatus();
+                Status.Code code = status.getCode();
                 responseMessage += code.value() + " " + code.name();
-                responseData += code.value() + " " + throwable.getMessage();
+                responseData = status.getDescription();
             } else {
                 responseMessage += ExceptionUtils.getPrintExceptionToStr(throwable, 0);
                 responseData = responseMessage;

--- a/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
+++ b/src/main/java/vn/zalopay/benchmark/GRPCSampler.java
@@ -8,6 +8,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import vn.zalopay.benchmark.constant.GrpcSamplerConstant;
 import vn.zalopay.benchmark.core.ClientCaller;
 import vn.zalopay.benchmark.core.config.GrpcRequestConfig;
 import vn.zalopay.benchmark.core.specification.GrpcResponse;
@@ -88,7 +89,7 @@ public class GRPCSampler extends AbstractSampler implements ThreadListener {
             sampleResult.setSuccessful(false);
             sampleResult.setResponseCode(" 400");
             sampleResult.setDataType(SampleResult.TEXT);
-            sampleResult.setResponseMessage(" GRPCSampler parsing exception: An unknown exception occurred before the GRPC request was initiated, See response body for the stack trace.");
+            sampleResult.setResponseMessage(GrpcSamplerConstant.CLIENT_EXCEPTION_MSG);
             sampleResult.setResponseData(ExceptionUtils.getPrintExceptionToStr(e, null), "UTF-8");
             return sampleResult;
         }

--- a/src/main/java/vn/zalopay/benchmark/constant/GrpcSamplerConstant.java
+++ b/src/main/java/vn/zalopay/benchmark/constant/GrpcSamplerConstant.java
@@ -1,0 +1,16 @@
+package vn.zalopay.benchmark.constant;
+
+/**
+ * GrpcSampler constant definition
+ *
+ * @author ylyue
+ * @since 2022/7/11
+ */
+public class GrpcSamplerConstant {
+
+    /**
+     * Client exception message - http 400
+     */
+    public static final String CLIENT_EXCEPTION_MSG = " GRPCSampler parsing exception: An unknown exception occurred before the GRPC request was initiated, See response body for the stack trace.";
+
+}

--- a/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
@@ -148,28 +148,28 @@ public class ClientCaller {
 
     public GrpcResponse call(String deadlineMs) {
         long deadline = parsingDeadlineTime(deadlineMs);
-        GrpcResponse output = new GrpcResponse();
-        StreamObserver<DynamicMessage> streamObserver = ComponentObserver.of(Writer.create(output, registry));
+        GrpcResponse grpcResponse = new GrpcResponse();
+        StreamObserver<DynamicMessage> streamObserver = ComponentObserver.of(Writer.create(grpcResponse, registry));
         try {
             dynamicClient.blockingUnaryCall(requestMessages, streamObserver, callOptions(deadline)).get();
         } catch (Throwable t) {
             shutdownNettyChannel();
-            throw new RuntimeException("Caught exception while waiting for rpc", t);
         }
-        return output;
+
+        return grpcResponse;
     }
 
     public GrpcResponse callServerStreaming(String deadlineMs) {
         long deadline = parsingDeadlineTime(deadlineMs);
-        GrpcResponse output = new GrpcResponse();
-        StreamObserver<DynamicMessage> streamObserver = ComponentObserver.of(Writer.create(output, registry));
+        GrpcResponse grpcResponse = new GrpcResponse();
+        StreamObserver<DynamicMessage> streamObserver = ComponentObserver.of(Writer.create(grpcResponse, registry));
         try {
             dynamicClient.callServerStreaming(requestMessages, streamObserver, callOptions(deadline)).get();
         } catch (Throwable t) {
             shutdownNettyChannel();
-            throw new RuntimeException("Caught exception while waiting for rpc", t);
         }
-        return output;
+
+        return grpcResponse;
     }
 
     public GrpcResponse callClientStreaming(String deadlineMs) {

--- a/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
+++ b/src/main/java/vn/zalopay/benchmark/core/ClientCaller.java
@@ -59,8 +59,7 @@ public class ClientCaller {
             hostAndPort = HostAndPort.fromString(hostPort);
             metadataMap = new LinkedHashMap<>();
             channelFactory = ChannelFactory.create();
-            ProtoMethodName grpcMethodName =
-                    ProtoMethodName.parseFullGrpcMethodName(fullMethod);
+            ProtoMethodName grpcMethodName = ProtoMethodName.parseFullGrpcMethodName(fullMethod);
 
             // Fetch the appropriate file descriptors for the service.
             final DescriptorProtos.FileDescriptorSet fileDescriptorSet;
@@ -69,7 +68,7 @@ public class ClientCaller {
                 fileDescriptorSet = ProtocInvoker.forConfig(testProtoFiles, libFolder).invoke();
             } catch (Exception e) {
                 shutdownNettyChannel();
-                throw new RuntimeException("Unable to resolve service by invoking protoc", e);
+                throw new RuntimeException("Unable to resolve service by invoking protoc: \n" + e.getMessage(), e);
             }
 
             // Set up the dynamic client and make the call.

--- a/src/main/java/vn/zalopay/benchmark/core/message/Reader.java
+++ b/src/main/java/vn/zalopay/benchmark/core/message/Reader.java
@@ -1,11 +1,11 @@
 package vn.zalopay.benchmark.core.message;
 
 
-import com.alibaba.fastjson.JSONObject;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.util.JsonFormat;
+import org.apache.commons.lang3.StringUtils;
 import vn.zalopay.benchmark.exception.GrpcPluginException;
 
 public class Reader {
@@ -30,7 +30,9 @@ public class Reader {
         try {
             // Parses from JSON into a protobuf message.
             DynamicMessage.Builder nextMessage = DynamicMessage.newBuilder(descriptor);
-            jsonParser.merge(payload, nextMessage);
+            if (StringUtils.isNotBlank(payload)) {
+                jsonParser.merge(payload, nextMessage);
+            }
 
             // Clean up and prepare for next message.
             resultBuilder.add(nextMessage.build());

--- a/src/main/java/vn/zalopay/benchmark/core/message/Writer.java
+++ b/src/main/java/vn/zalopay/benchmark/core/message/Writer.java
@@ -38,7 +38,6 @@ public class Writer<T extends Message> implements StreamObserver<T> {
     public void onError(Throwable throwable) {
         grpcResponse.setSuccess(false);
         grpcResponse.setThrowable(throwable);
-        LOGGER.error(throwable.getMessage());
     }
 
     @Override

--- a/src/main/java/vn/zalopay/benchmark/core/message/Writer.java
+++ b/src/main/java/vn/zalopay/benchmark/core/message/Writer.java
@@ -10,43 +10,45 @@ import org.slf4j.LoggerFactory;
 import vn.zalopay.benchmark.core.specification.GrpcResponse;
 
 public class Writer<T extends Message> implements StreamObserver<T> {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Writer.class);
 
     private final JsonFormat.Printer jsonPrinter;
-    private final GrpcResponse output;
+    private final GrpcResponse grpcResponse;
+
+    Writer(JsonFormat.Printer jsonPrinter, GrpcResponse grpcResponse) {
+        this.jsonPrinter = jsonPrinter.preservingProtoFieldNames().includingDefaultValueFields();
+        this.grpcResponse = grpcResponse;
+    }
 
     /**
      * Creates a new Writer which writes the messages it sees to the supplied
      * Output.
      */
-    public static <T extends Message> Writer<T> create(GrpcResponse output, JsonFormat.TypeRegistry registry) {
-        return new Writer<>(JsonFormat.printer().usingTypeRegistry(registry), output);
-    }
-
-    Writer(JsonFormat.Printer jsonPrinter, GrpcResponse output) {
-        this.jsonPrinter = jsonPrinter.preservingProtoFieldNames().includingDefaultValueFields();
-        this.output = output;
+    public static <T extends Message> Writer<T> create(GrpcResponse grpcResponse, JsonFormat.TypeRegistry registry) {
+        return new Writer<>(JsonFormat.printer().usingTypeRegistry(registry), grpcResponse);
     }
 
     @Override
     public void onCompleted() {
-        LOGGER.debug("On completed gRPC message: {}", output.getGrpcMessageString());
+        LOGGER.debug("On completed gRPC message: {}", grpcResponse.getGrpcMessageString());
     }
 
     @Override
     public void onError(Throwable throwable) {
-        String stacktrace = ExceptionUtils.getStackTrace(throwable);
-        String throwMsg = throwable.getMessage();
-        output.storeGrpcMessage(String.format("%s. %s", throwMsg, stacktrace));
+        grpcResponse.setSuccess(false);
+        grpcResponse.setThrowable(throwable);
         LOGGER.error(throwable.getMessage());
     }
 
     @Override
     public void onNext(T message) {
         try {
-            output.storeGrpcMessage(jsonPrinter.print(message));
+            grpcResponse.setSuccess(true);
+            grpcResponse.storeGrpcMessage(jsonPrinter.print(message));
         } catch (InvalidProtocolBufferException e) {
             LOGGER.warn(e.getMessage());
         }
     }
+
 }

--- a/src/main/java/vn/zalopay/benchmark/core/message/Writer.java
+++ b/src/main/java/vn/zalopay/benchmark/core/message/Writer.java
@@ -4,7 +4,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.stub.StreamObserver;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import vn.zalopay.benchmark.core.specification.GrpcResponse;

--- a/src/main/java/vn/zalopay/benchmark/core/protobuf/ProtocInvoker.java
+++ b/src/main/java/vn/zalopay/benchmark/core/protobuf/ProtocInvoker.java
@@ -247,7 +247,7 @@ public class ProtocInvoker {
     /**
      * An error indicating that something went wrong while invoking protoc.
      */
-    public class ProtocInvocationException extends Exception {
+    public class ProtocInvocationException extends RuntimeException {
         private static final long serialVersionUID = 1L;
 
         private ProtocInvocationException(String message) {
@@ -272,10 +272,14 @@ public class ProtocInvoker {
         }
 
         throw new ProtocInvocationException(
-                String.format("Got error exit code [%d] from protoc: protoc command [%s] has " +
-                                "error" +
-                                " [%s]",
+                String.format("\nProtoc error exit code: %d\n\n" +
+                                "Protoc execute command: \n\t%s\n\n" +
+                                "Protoc execute error: \n\t%s\n",
                         status,
-                        String.join("\n", protocInfoLogLines), String.join("\n", protocErrorLogLines)));
+                        String.join("\n\t", protocInfoLogLines),
+                        String.join("\n\t", protocErrorLogLines)
+                )
+        );
     }
+
 }

--- a/src/main/java/vn/zalopay/benchmark/core/specification/GrpcResponse.java
+++ b/src/main/java/vn/zalopay/benchmark/core/specification/GrpcResponse.java
@@ -4,10 +4,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GrpcResponse {
+
+    private boolean success;
+    private Throwable throwable;
     private final List<Object> output;
 
     public GrpcResponse() {
         output = new ArrayList<>();
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
     }
 
     public void storeGrpcMessage(Object message) {
@@ -15,8 +34,10 @@ public class GrpcResponse {
     }
 
     public String getGrpcMessageString() {
-        if (output.size() == 1)
+        if (output.size() == 1) {
             return output.get(0).toString();
+        }
+
         return output.toString();
     }
 

--- a/src/main/java/vn/zalopay/benchmark/util/ExceptionUtils.java
+++ b/src/main/java/vn/zalopay/benchmark/util/ExceptionUtils.java
@@ -3,11 +3,11 @@ package vn.zalopay.benchmark.util;
 import com.alibaba.fastjson.JSONObject;
 
 /**
- * <b>异常打印工具类</b>
+ * <b>Exception print utility class</b>
  * <p>reference: https://github.com/yl-yue/yue-library/blob/j11.2.6.0/yue-library-base/src/main/java/ai/yue/library/base/util/ExceptionUtils.java</p>
  *
  * @author	ylyue
- * @since	2018年9月9日
+ * @since	2018-9-9
  */
 public class ExceptionUtils {
 
@@ -60,22 +60,22 @@ public class ExceptionUtils {
 	}
 	
 	/**
-	 * 获得打印异常内容
-	 * <p>默认只打印关键的5行内容
+	 * Get print abnormal content
+	 * <p>By default, only five key lines are printed
 	 * 
-	 * @param e 异常
-	 * @return 异常内容
+	 * @param e exception
+	 * @return exception data
 	 */
 	public synchronized static String getPrintExceptionToStr(Throwable e) {
 		return getPrintExceptionToStr(e, 4);
 	}
 	
 	/**
-	 * 获得打印异常内容
+	 * Get print abnormal content
 	 * 
-	 * @param e    异常
-	 * @param line 打印行数
-	 * @return 异常内容
+	 * @param e    exception
+	 * @param line Print the number of rows
+	 * @return exception data
 	 */
 	public synchronized static String getPrintExceptionToStr(Throwable e, Integer line) {
 		StringBuffer printException = getPrintException(e, line, ExceptionConvertEnum.StringBuffer);
@@ -83,42 +83,42 @@ public class ExceptionUtils {
 	}
 	
 	/**
-	 * 获得打印异常内容
-	 * <p>默认只打印关键的5行内容
+	 * Get print abnormal content
+	 * <p>By default, only five key lines are printed
 	 * 
-	 * @param e    异常
-	 * @return 异常内容
+	 * @param e    exception
+	 * @return exception data
 	 */
 	public synchronized static JSONObject getPrintExceptionToJson(Throwable e) {
 		return getPrintExceptionToJson(e, 4);
 	}
 	
 	/**
-	 * 获得打印异常内容
+	 * Get print abnormal content
 	 * 
-	 * @param e    异常
-	 * @param line 打印行数
-	 * @return 异常内容
+	 * @param e    exception
+	 * @param line Print the number of rows
+	 * @return exception data
 	 */
 	public synchronized static JSONObject getPrintExceptionToJson(Throwable e, Integer line) {
 		return getPrintException(e, line, ExceptionConvertEnum.JSONObject);
 	}
 	
 	/**
-	 * 获得打印异常内容
-	 * <p>默认只打印关键的5行内容
+	 * Get print abnormal content
+	 * <p>By default, only five key lines are printed
 	 * 
-	 * @param e    异常
+	 * @param e    exception
 	 */
 	public synchronized static void printException(Throwable e) {
 		printException(e, 4);
 	}
 	
 	/**
-	 * 获得打印异常内容
+	 * Get print abnormal content
 	 * 
-	 * @param e    异常
-	 * @param line 打印行数
+	 * @param e    exception
+	 * @param line Print the number of rows
 	 */
 	public synchronized static void printException(Throwable e, Integer line) {
 		System.err.print(getPrintExceptionToStr(e, line));

--- a/src/main/java/vn/zalopay/benchmark/util/ExceptionUtils.java
+++ b/src/main/java/vn/zalopay/benchmark/util/ExceptionUtils.java
@@ -1,0 +1,131 @@
+package vn.zalopay.benchmark.util;
+
+import com.alibaba.fastjson.JSONObject;
+
+/**
+ * <b>异常打印工具类</b>
+ * <p>reference: https://github.com/yl-yue/yue-library/blob/j11.2.6.0/yue-library-base/src/main/java/ai/yue/library/base/util/ExceptionUtils.java</p>
+ *
+ * @author	ylyue
+ * @since	2018年9月9日
+ */
+public class ExceptionUtils {
+
+	@SuppressWarnings("unchecked")
+	private synchronized static <T> T getPrintException(Throwable e, Integer line, ExceptionConvertEnum exceptionConvertEnum) {
+		T msg = null;
+		if (exceptionConvertEnum == ExceptionConvertEnum.JSONObject) {
+			msg = (T) new JSONObject(true);
+			if (e == null) {
+				((JSONObject) msg).put("0", "The stack trace is null");
+				return msg;
+			} else {
+				((JSONObject) msg).put("0", e.toString());
+			}
+		} else if (exceptionConvertEnum == ExceptionConvertEnum.StringBuffer) {
+			msg = (T) new StringBuffer();
+			if (e == null) {
+				((StringBuffer) msg).append("The stack trace is null");
+				return msg;
+			} else {
+				((StringBuffer) msg).append(e + "\n");
+			}
+		}
+		
+		StackTraceElement[] stackTraceElementArray = e.getStackTrace();
+		int maxLine = stackTraceElementArray.length;
+		if (line == null) {
+			line = maxLine;
+		} else {
+			line = line > maxLine ? maxLine : line;
+		}
+		
+		for (int i = 0; i < line; i++) {
+			StackTraceElement stackTraceElement = stackTraceElementArray[i];
+			String fileName = stackTraceElement.getFileName();
+			String className = stackTraceElement.getClassName();
+			String methodName = stackTraceElement.getMethodName();
+			int lineNumber = stackTraceElement.getLineNumber();
+			
+			if (exceptionConvertEnum == ExceptionConvertEnum.JSONObject) {
+				((JSONObject) msg).put(i + 1 + "", "　　at " + className + "." + methodName + "(" + fileName + ":" + lineNumber + ")");
+			}
+			
+			if (exceptionConvertEnum == ExceptionConvertEnum.StringBuffer) {
+				((StringBuffer) msg).append("\tat " + className + "." + methodName + "(" + fileName + ":" + lineNumber + ")\n");
+			}
+		}
+		
+		return msg;
+	}
+	
+	/**
+	 * 获得打印异常内容
+	 * <p>默认只打印关键的5行内容
+	 * 
+	 * @param e 异常
+	 * @return 异常内容
+	 */
+	public synchronized static String getPrintExceptionToStr(Throwable e) {
+		return getPrintExceptionToStr(e, 4);
+	}
+	
+	/**
+	 * 获得打印异常内容
+	 * 
+	 * @param e    异常
+	 * @param line 打印行数
+	 * @return 异常内容
+	 */
+	public synchronized static String getPrintExceptionToStr(Throwable e, Integer line) {
+		StringBuffer printException = getPrintException(e, line, ExceptionConvertEnum.StringBuffer);
+		return printException.toString();
+	}
+	
+	/**
+	 * 获得打印异常内容
+	 * <p>默认只打印关键的5行内容
+	 * 
+	 * @param e    异常
+	 * @return 异常内容
+	 */
+	public synchronized static JSONObject getPrintExceptionToJson(Throwable e) {
+		return getPrintExceptionToJson(e, 4);
+	}
+	
+	/**
+	 * 获得打印异常内容
+	 * 
+	 * @param e    异常
+	 * @param line 打印行数
+	 * @return 异常内容
+	 */
+	public synchronized static JSONObject getPrintExceptionToJson(Throwable e, Integer line) {
+		return getPrintException(e, line, ExceptionConvertEnum.JSONObject);
+	}
+	
+	/**
+	 * 获得打印异常内容
+	 * <p>默认只打印关键的5行内容
+	 * 
+	 * @param e    异常
+	 */
+	public synchronized static void printException(Throwable e) {
+		printException(e, 4);
+	}
+	
+	/**
+	 * 获得打印异常内容
+	 * 
+	 * @param e    异常
+	 * @param line 打印行数
+	 */
+	public synchronized static void printException(Throwable e, Integer line) {
+		System.err.print(getPrintExceptionToStr(e, line));
+	}
+	
+	private enum ExceptionConvertEnum {
+		JSONObject, StringBuffer;
+	}
+	
+}

--- a/src/test/java/vn/zalopay/benchmark/core/BaseTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/BaseTest.java
@@ -21,6 +21,8 @@ public class BaseTest {
     protected static final Path JMETER_PROPERTIES_FILE = Paths.get(System.getProperty("user.dir"), "src", "test", "resources", "jmeter.properties");
     protected static final Path PROTO_WITH_EXTERNAL_IMPORT_FOLDER =
             Paths.get(System.getProperty("user.dir"), "dist/benchmark/grpc-server/src/main/resources/protos-v2");
+    protected static final Path PROTO_PATH_WITH_ERROR_IMPORT_FOLDER =
+            Paths.get(System.getProperty("user.dir"), "dist/benchmark/grpc-server/src/main/resources/protos-error");
     protected static final Path PROTO_PATH_WITH_INVALID_FILE_PATH =
             Paths.get(System.getProperty("user.dir"), "dist/benchmark/grpc-server/src/main/resources/protos-v2/shelf.proto1");
     protected static final Path PROTO_FOLDER =
@@ -31,6 +33,7 @@ public class BaseTest {
     protected static String HOST_PORT_TLS = "localhost:8006";
     protected static String REQUEST_JSON = "{\"shelf\":{\"id\":1599156420811,\"theme\":\"Hello server!!\"}}";
     protected static String FULL_METHOD = "bookstore.Bookstore/CreateShelf";
+    protected static String FULL_METHOD_INVALID = "bookstore.Bookstore/Invalid";
     protected static String METADATA = "";
     protected static final GrpcRequestConfig DEFAULT_GRPC_REQUEST_CONFIG =
             new GrpcRequestConfig(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(),

--- a/src/test/java/vn/zalopay/benchmark/core/client/ClientCallerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/client/ClientCallerTest.java
@@ -2,6 +2,7 @@ package vn.zalopay.benchmark.core.client;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
@@ -270,18 +271,18 @@ public class ClientCallerTest extends BaseTest {
         clientCaller = new ClientCaller(grpcRequestConfig);
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")
-    public void testThrowExceptionWithTimeoutRequest() {
+    @Test(expectedExceptions = StatusRuntimeException.class, expectedExceptionsMessageRegExp = "DEADLINE_EXCEEDED: .*")
+    public void testThrowExceptionWithTimeoutRequest() throws Throwable {
         clientCaller = new ClientCaller(DEFAULT_GRPC_REQUEST_CONFIG);
         clientCaller.buildRequestAndMetadata(REQUEST_JSON, METADATA);
         GrpcResponse resp = clientCaller.call("1");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
-        Assert.assertTrue(resp.getGrpcMessageString().contains("\"theme\": \"Hello server"));
+        throw resp.getThrowable();
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")
-    public void testThrowExceptionWithTimeoutRequestServerStream() {
+    @Test(expectedExceptions = StatusRuntimeException.class, expectedExceptionsMessageRegExp = "DEADLINE_EXCEEDED: .*")
+    public void testThrowExceptionWithTimeoutRequestServerStream() throws Throwable {
         GrpcRequestConfig grpcRequestConfig = new GrpcRequestConfig(HOST_PORT, PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString(), LIB_FOLDER.toString(),
                 "bookstore.Bookstore/GetShelfStreamServer", false, false, DEFAULT_CHANNEL_SHUTDOWN_TIME);
         clientCaller = new ClientCaller(grpcRequestConfig);
@@ -289,7 +290,7 @@ public class ClientCallerTest extends BaseTest {
         GrpcResponse resp = clientCaller.callServerStreaming("1");
         clientCaller.shutdownNettyChannel();
         Assert.assertNotNull(resp);
-        Assert.assertTrue(resp.getGrpcMessageString().contains("\"theme\": \"Hello server"));
+        throw resp.getThrowable();
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Caught exception while waiting for rpc")

--- a/src/test/java/vn/zalopay/benchmark/core/client/ClientCallerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/client/ClientCallerTest.java
@@ -231,7 +231,7 @@ public class ClientCallerTest extends BaseTest {
         clientCaller.call("1000");
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Unable to resolve service by invoking protoc")
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Unable to resolve service by invoking protoc.*")
     public void testThrowExceptionWithExceptionInProtocInvoke() {
         MockedStatic<ProtocInvoker> protocInvoker = Mockito.mockStatic(ProtocInvoker.class);
         protocInvoker.when(() -> ProtocInvoker.forConfig(Mockito.anyString(), Mockito.anyString()).invoke())

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GRPCSamplerGuiTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GRPCSamplerGuiTest.java
@@ -1,18 +1,23 @@
 package vn.zalopay.benchmark.core.sampler;
 
+import com.google.common.net.HostAndPort;
 import org.apache.jmeter.sampler.DebugSampler;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.visualizers.RenderAsText;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import vn.zalopay.benchmark.GRPCSampler;
 import vn.zalopay.benchmark.GRPCSamplerGui;
+import vn.zalopay.benchmark.constant.GrpcSamplerConstant;
 import vn.zalopay.benchmark.core.BaseTest;
+import vn.zalopay.benchmark.core.test.dependency.ViewResultsFullVisualizerGui;
 
 import javax.swing.*;
 import java.awt.*;
 import java.lang.reflect.Field;
 
-
 public class GRPCSamplerGuiTest extends BaseTest {
+
     @Test
     public void testCanShowGui() {
         GRPCSamplerGui grpRequestPluginGUI = new GRPCSamplerGui();
@@ -219,4 +224,54 @@ public class GRPCSamplerGuiTest extends BaseTest {
         Assert.assertNotNull(grpRequestPluginGUI);
         frame.dispose();
     }
+
+    @Test
+    public void testExceptionRequestWithListenerResultTree() throws Exception {
+        // init window
+        RenderAsText samplerResultTab = new RenderAsText();
+        ViewResultsFullVisualizerGui viewResultsFullVisualizerGui = new ViewResultsFullVisualizerGui(samplerResultTab);
+        JFrame frame = new JFrame("testExceptionRequestListenerResultTree");
+        frame.setPreferredSize(new Dimension(1024, 768));
+        Container contentPane = frame.getContentPane();
+        contentPane.add(viewResultsFullVisualizerGui, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+
+        // exec request
+        HostAndPort hostAndPort = HostAndPort.fromString(HOST_PORT);
+        GRPCSampler grpcSampler = new GRPCSampler();
+        grpcSampler.setName("testExceptionRequestListenerResultTree");
+        grpcSampler.setComment("dummyComment");
+        grpcSampler.setProtoFolder(PROTO_PATH_WITH_ERROR_IMPORT_FOLDER.toString());
+        grpcSampler.setLibFolder(LIB_FOLDER.toString());
+        grpcSampler.setMetadata(METADATA);
+        grpcSampler.setHost(hostAndPort.getHost());
+        grpcSampler.setPort(Integer.toString(hostAndPort.getPort()));
+        grpcSampler.setFullMethod(FULL_METHOD_INVALID);
+        grpcSampler.setDeadline("2000");
+        grpcSampler.setTls(false);
+        grpcSampler.setTlsDisableVerification(false);
+        grpcSampler.setChannelShutdownAwaitTime("5000");
+        grpcSampler.setRequestJson(REQUEST_JSON);
+        grpcSampler.threadStarted();
+        SampleResult sampleResult = grpcSampler.sample(null);
+
+        // set result
+        viewResultsFullVisualizerGui.add(sampleResult);
+        Assert.assertEquals(sampleResult.getResponseCode(), " 400");
+        Assert.assertEquals(sampleResult.getResponseMessage(), GrpcSamplerConstant.CLIENT_EXCEPTION_MSG);
+        Assert.assertTrue(new String(sampleResult.getResponseData()).contains("invalid.proto:11:1: File recursively imports itself: invalid.proto -> invalid.proto"));
+
+        // Destruction of the view
+        frame.dispose();
+
+        // Leave the view and wait indefinitely so that the JVM does not exit and the results are verified manually
+//        Object lock = new Object();
+//        while (true) {
+//            synchronized (lock) {
+//                lock.wait();
+//            }
+//        }
+    }
+
 }

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GRPCSamplerGuiTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GRPCSamplerGuiTest.java
@@ -262,10 +262,10 @@ public class GRPCSamplerGuiTest extends BaseTest {
         Assert.assertEquals(sampleResult.getResponseMessage(), GrpcSamplerConstant.CLIENT_EXCEPTION_MSG);
         Assert.assertTrue(new String(sampleResult.getResponseData()).contains("invalid.proto:11:1: File recursively imports itself: invalid.proto -> invalid.proto"));
 
-        // Destruction of the view
+        // GUI observation: Destruction of the view
         frame.dispose();
 
-        // Leave the view and wait indefinitely so that the JVM does not exit and the results are verified manually
+        // GUI observation: Leave the view and wait indefinitely so that the JVM does not exit and the results are verified manually
 //        Object lock = new Object();
 //        while (true) {
 //            synchronized (lock) {

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
@@ -108,7 +108,7 @@ public class GrpcSamplerTest extends BaseTest {
         grpcSampler.threadFinished();
         grpcSampler.clear();
         Assert.assertEquals(sampleResult.getResponseCode(), " 500");
-        Assert.assertTrue(new String(sampleResult.getResponseData()).contains(" 4 DEADLINE_EXCEEDED:"));
+        Assert.assertTrue(sampleResult.getResponseMessage().contains("4 DEADLINE_EXCEEDED"));
     }
 
     @Test

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
@@ -138,7 +138,7 @@ public class GrpcSamplerTest extends BaseTest {
         grpcSampler.threadFinished();
         grpcSampler.clear();
         Assert.assertEquals(sampleResult.getResponseCode(), "500");
-        Assert.assertTrue(new String(sampleResult.getResponseData()).contains("Exception: io.grpc.StatusRuntimeException"));
+        Assert.assertTrue(new String(sampleResult.getResponseMessage()).contains(" The stack trace is null"));
     }
 
     @Test

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
@@ -107,8 +107,8 @@ public class GrpcSamplerTest extends BaseTest {
         SampleResult sampleResult = grpcSampler.sample(null);
         grpcSampler.threadFinished();
         grpcSampler.clear();
-        Assert.assertEquals(sampleResult.getResponseCode(), "500");
-        Assert.assertTrue(new String(sampleResult.getResponseData()).contains("io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED:"));
+        Assert.assertEquals(sampleResult.getResponseCode(), " 500");
+        Assert.assertTrue(new String(sampleResult.getResponseData()).contains(" 4 DEADLINE_EXCEEDED:"));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class GrpcSamplerTest extends BaseTest {
         SampleResult sampleResult = grpcSampler.sample(null);
         grpcSampler.threadFinished();
         grpcSampler.clear();
-        Assert.assertEquals(sampleResult.getResponseCode(), "500");
+        Assert.assertEquals(sampleResult.getResponseCode(), " 500");
         Assert.assertTrue(new String(sampleResult.getResponseMessage()).contains(" The stack trace is null"));
     }
 

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
@@ -162,6 +162,8 @@ public class GrpcSamplerTest extends BaseTest {
         SampleResult sampleResult = grpcSampler.sample(null);
         Assert.assertEquals(sampleResult.getResponseCode(), " 400");
         Assert.assertEquals(sampleResult.getResponseMessage(), GrpcSamplerConstant.CLIENT_EXCEPTION_MSG);
+        String s = new String(sampleResult.getResponseData());
+        System.out.println(s);
         Assert.assertTrue(new String(sampleResult.getResponseData()).contains("invalid.proto:11:1: File recursively imports itself: invalid.proto -> invalid.proto"));
     }
 

--- a/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
+++ b/src/test/java/vn/zalopay/benchmark/core/sampler/GrpcSamplerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import vn.zalopay.benchmark.GRPCSampler;
+import vn.zalopay.benchmark.constant.GrpcSamplerConstant;
 import vn.zalopay.benchmark.core.BaseTest;
 import vn.zalopay.benchmark.core.ClientCaller;
 import vn.zalopay.benchmark.core.message.Writer;
@@ -139,6 +140,52 @@ public class GrpcSamplerTest extends BaseTest {
         grpcSampler.clear();
         Assert.assertEquals(sampleResult.getResponseCode(), " 500");
         Assert.assertTrue(new String(sampleResult.getResponseMessage()).contains(" The stack trace is null"));
+    }
+
+    @Test
+    public void testCanSendSampleRequestWithErrorProtoFolder() {
+        HostAndPort hostAndPort = HostAndPort.fromString(HOST_PORT);
+        GRPCSampler grpcSampler = new GRPCSampler();
+        grpcSampler.setComment("dummyComment");
+        grpcSampler.setProtoFolder(PROTO_PATH_WITH_ERROR_IMPORT_FOLDER.toString());
+        grpcSampler.setLibFolder(LIB_FOLDER.toString());
+        grpcSampler.setMetadata(METADATA);
+        grpcSampler.setHost(hostAndPort.getHost());
+        grpcSampler.setPort(Integer.toString(hostAndPort.getPort()));
+        grpcSampler.setFullMethod(FULL_METHOD_INVALID);
+        grpcSampler.setDeadline("2000");
+        grpcSampler.setTls(false);
+        grpcSampler.setTlsDisableVerification(false);
+        grpcSampler.setChannelShutdownAwaitTime("5000");
+        grpcSampler.setRequestJson(REQUEST_JSON);
+        grpcSampler.threadStarted();
+        SampleResult sampleResult = grpcSampler.sample(null);
+        Assert.assertEquals(sampleResult.getResponseCode(), " 400");
+        Assert.assertEquals(sampleResult.getResponseMessage(), GrpcSamplerConstant.CLIENT_EXCEPTION_MSG);
+        Assert.assertTrue(new String(sampleResult.getResponseData()).contains("invalid.proto:11:1: File recursively imports itself: invalid.proto -> invalid.proto"));
+    }
+
+    @Test
+    public void testCanSendSampleRequestWithErrorFullMethod() {
+        HostAndPort hostAndPort = HostAndPort.fromString(HOST_PORT);
+        GRPCSampler grpcSampler = new GRPCSampler();
+        grpcSampler.setComment("dummyComment");
+        grpcSampler.setProtoFolder(PROTO_WITH_EXTERNAL_IMPORT_FOLDER.toString());
+        grpcSampler.setLibFolder(LIB_FOLDER.toString());
+        grpcSampler.setMetadata(METADATA);
+        grpcSampler.setHost(hostAndPort.getHost());
+        grpcSampler.setPort(Integer.toString(hostAndPort.getPort()));
+        grpcSampler.setFullMethod(FULL_METHOD_INVALID);
+        grpcSampler.setDeadline("2000");
+        grpcSampler.setTls(false);
+        grpcSampler.setTlsDisableVerification(false);
+        grpcSampler.setChannelShutdownAwaitTime("5000");
+        grpcSampler.setRequestJson(REQUEST_JSON);
+        grpcSampler.threadStarted();
+        SampleResult sampleResult = grpcSampler.sample(null);
+        Assert.assertEquals(sampleResult.getResponseCode(), " 400");
+        Assert.assertEquals(sampleResult.getResponseMessage(), GrpcSamplerConstant.CLIENT_EXCEPTION_MSG);
+        Assert.assertTrue(new String(sampleResult.getResponseData()).contains("Unable to find method Invalid in service Bookstore"));
     }
 
     @Test

--- a/src/test/java/vn/zalopay/benchmark/core/test/dependency/ViewResultsFullVisualizerGui.java
+++ b/src/test/java/vn/zalopay/benchmark/core/test/dependency/ViewResultsFullVisualizerGui.java
@@ -1,0 +1,577 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed  under the  License is distributed on an "AS IS" BASIS,
+ * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package vn.zalopay.benchmark.core.test.dependency;
+
+import org.apache.commons.collections.Buffer;
+import org.apache.commons.collections.EnumerationUtils;
+import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.commons.collections.buffer.UnboundedFifoBuffer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jmeter.JMeter;
+import org.apache.jmeter.assertions.AssertionResult;
+import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.util.VerticalPanel;
+import org.apache.jmeter.samplers.Clearable;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.visualizers.*;
+import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.Timer;
+import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeSelectionListener;
+import javax.swing.tree.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.io.IOException;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Base for ViewResults
+ */
+@GUIMenuSortOrder(1)
+public class ViewResultsFullVisualizerGui extends AbstractVisualizer
+        implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LoggerFactory.getLogger(org.apache.jmeter.visualizers.ViewResultsFullVisualizer.class);
+
+    public static final Color SERVER_ERROR_COLOR = Color.red;
+    public static final Color CLIENT_ERROR_COLOR = Color.blue;
+    public static final Color REDIRECT_COLOR = Color.green;
+
+    protected static final String COMBO_CHANGE_COMMAND = "change_combo"; // $NON-NLS-1$
+
+    private static final Border RED_BORDER = BorderFactory.createLineBorder(Color.red);
+    private static final Border BLUE_BORDER = BorderFactory.createLineBorder(Color.blue);
+    private static final String ICON_SIZE = JMeterUtils.getPropDefault(JMeter.TREE_ICON_SIZE, JMeter.DEFAULT_TREE_ICON_SIZE);
+
+    // Default limited to 10 megabytes
+    private static final int MAX_DISPLAY_SIZE =
+            JMeterUtils.getPropDefault("view.results.tree.max_size", 10485760); // $NON-NLS-1$
+
+    // default display order
+    private static final String VIEWERS_ORDER =
+            JMeterUtils.getPropDefault("view.results.tree.renderers_order", ""); // $NON-NLS-1$ //$NON-NLS-2$
+
+    private static final int REFRESH_PERIOD = JMeterUtils.getPropDefault("jmeter.gui.refresh_period", 500);
+
+    private static final ImageIcon imageSuccess = JMeterUtils.getImage(
+            JMeterUtils.getPropDefault("viewResultsTree.success",  //$NON-NLS-1$
+                    "vrt/" + ICON_SIZE + "/security-high-2.png")); //$NON-NLS-1$ $NON-NLS-2$
+
+    private static final ImageIcon imageFailure = JMeterUtils.getImage(
+            JMeterUtils.getPropDefault("viewResultsTree.failure",  //$NON-NLS-1$
+                    "vrt/" + ICON_SIZE + "/security-low-2.png")); //$NON-NLS-1$ $NON-NLS-2$
+
+    private JSplitPane mainSplit;
+    private DefaultMutableTreeNode root;
+    private DefaultTreeModel treeModel;
+    private JTree jTree;
+    private Component leftSide;
+    private JTabbedPane rightSide;
+    private JComboBox<ResultRenderer> selectRenderPanel;
+    private int selectedTab;
+    private ResultRenderer resultsRender = null;
+    private Object resultsObject = null;
+    private TreeSelectionEvent lastSelectionEvent;
+    private JCheckBox autoScrollCB;
+    private Buffer buffer;
+    private boolean dataChanged;
+
+    /**
+     * Constructor
+     */
+    public ViewResultsFullVisualizerGui(SamplerResultTab samplerResultTab) {
+        super();
+        final int maxResults = JMeterUtils.getPropDefault("view.results.tree.max_results", 500);
+        if (maxResults > 0) {
+            buffer = new CircularFifoBuffer(maxResults);
+        } else {
+            buffer = new UnboundedFifoBuffer();
+        }
+        init(samplerResultTab);
+        new Timer(REFRESH_PERIOD, e -> updateGui()).start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void add(final SampleResult sample) {
+        synchronized (buffer) {
+            buffer.add(sample);
+            dataChanged = true;
+        }
+    }
+
+    /**
+     * Update the visualizer with new data.
+     */
+    private void updateGui() {
+        TreePath selectedPath = null;
+        Object oldSelectedElement;
+        Set<Object> oldExpandedElements;
+        Set<TreePath> newExpandedPaths = new HashSet<>();
+        synchronized (buffer) {
+            if (!dataChanged) {
+                return;
+            }
+
+            final Enumeration<TreePath> expandedElements = jTree.getExpandedDescendants(new TreePath(root));
+            oldExpandedElements = extractExpandedObjects(expandedElements);
+            oldSelectedElement = getSelectedObject();
+            root.removeAllChildren();
+            for (Object sampler : buffer) {
+                SampleResult res = (SampleResult) sampler;
+                // Add sample
+                DefaultMutableTreeNode currNode = new SearchableTreeNode(res, treeModel);
+                treeModel.insertNodeInto(currNode, root, root.getChildCount());
+                java.util.List<TreeNode> path = new ArrayList<>(Arrays.asList(root, currNode));
+                selectedPath = checkExpandedOrSelected(path,
+                        res, oldSelectedElement,
+                        oldExpandedElements, newExpandedPaths, selectedPath);
+                TreePath potentialSelection = addSubResults(currNode, res, path, oldSelectedElement, oldExpandedElements, newExpandedPaths);
+                if (potentialSelection != null) {
+                    selectedPath = potentialSelection;
+                }
+                // Add any assertion that failed as children of the sample node
+                AssertionResult[] assertionResults = res.getAssertionResults();
+                int assertionIndex = currNode.getChildCount();
+                for (AssertionResult assertionResult : assertionResults) {
+                    if (assertionResult.isFailure() || assertionResult.isError()) {
+                        DefaultMutableTreeNode assertionNode = new SearchableTreeNode(assertionResult, treeModel);
+                        treeModel.insertNodeInto(assertionNode, currNode, assertionIndex++);
+                        selectedPath = checkExpandedOrSelected(path,
+                                assertionResult, oldSelectedElement,
+                                oldExpandedElements, newExpandedPaths, selectedPath,
+                                assertionNode);
+                    }
+                }
+            }
+            treeModel.nodeStructureChanged(root);
+            dataChanged = false;
+        }
+
+        if (root.getChildCount() == 1) {
+            jTree.expandPath(new TreePath(root));
+        }
+        newExpandedPaths.stream().forEach(jTree::expandPath);
+        if (selectedPath != null) {
+            jTree.setSelectionPath(selectedPath);
+        }
+        if (autoScrollCB.isSelected() && root.getChildCount() > 1) {
+            jTree.scrollPathToVisible(new TreePath(new Object[]{root,
+                    treeModel.getChild(root, root.getChildCount() - 1)}));
+        }
+    }
+
+    private Object getSelectedObject() {
+        Object oldSelectedElement;
+        DefaultMutableTreeNode oldSelectedNode = (DefaultMutableTreeNode) jTree.getLastSelectedPathComponent();
+        oldSelectedElement = oldSelectedNode == null ? null : oldSelectedNode.getUserObject();
+        return oldSelectedElement;
+    }
+
+    private TreePath checkExpandedOrSelected(java.util.List<TreeNode> path,
+                                             Object item, Object oldSelectedObject,
+                                             Set<Object> oldExpandedObjects, Set<TreePath> newExpandedPaths,
+                                             TreePath defaultPath) {
+        TreePath result = defaultPath;
+        if (oldSelectedObject == item) {
+            result = toTreePath(path);
+        }
+        if (oldExpandedObjects.contains(item)) {
+            newExpandedPaths.add(toTreePath(path));
+        }
+        return result;
+    }
+
+    private TreePath checkExpandedOrSelected(java.util.List<TreeNode> path,
+                                             Object item, Object oldSelectedObject,
+                                             Set<Object> oldExpandedObjects, Set<TreePath> newExpandedPaths,
+                                             TreePath defaultPath, DefaultMutableTreeNode extensionNode) {
+        TreePath result = defaultPath;
+        if (oldSelectedObject == item) {
+            result = toTreePath(path, extensionNode);
+        }
+        if (oldExpandedObjects.contains(item)) {
+            newExpandedPaths.add(toTreePath(path, extensionNode));
+        }
+        return result;
+    }
+
+    private Set<Object> extractExpandedObjects(final Enumeration<TreePath> expandedElements) {
+        if (expandedElements != null) {
+            @SuppressWarnings("unchecked") final java.util.List<TreePath> list = EnumerationUtils.toList(expandedElements);
+            log.debug("Expanded: {}", list);
+            Set<Object> result = list.stream()
+                    .map(TreePath::getLastPathComponent)
+                    .map(c -> (DefaultMutableTreeNode) c)
+                    .map(DefaultMutableTreeNode::getUserObject)
+                    .collect(Collectors.toSet());
+            log.debug("Elements: {}", result);
+            return result;
+        }
+        return Collections.emptySet();
+    }
+
+    private TreePath addSubResults(DefaultMutableTreeNode currNode,
+                                   SampleResult res, java.util.List<TreeNode> path, Object selectedObject,
+                                   Set<Object> oldExpandedObjects, Set<TreePath> newExpandedPaths) {
+        SampleResult[] subResults = res.getSubResults();
+
+        int leafIndex = 0;
+        TreePath result = null;
+
+        for (SampleResult child : subResults) {
+            log.debug("updateGui1 : child sample result - {}", child);
+            DefaultMutableTreeNode leafNode = new SearchableTreeNode(child, treeModel);
+
+            treeModel.insertNodeInto(leafNode, currNode, leafIndex++);
+            java.util.List<TreeNode> newPath = new ArrayList<>(path);
+            newPath.add(leafNode);
+            result = checkExpandedOrSelected(newPath, child, selectedObject, oldExpandedObjects, newExpandedPaths, result);
+            addSubResults(leafNode, child, newPath, selectedObject, oldExpandedObjects, newExpandedPaths);
+            // Add any assertion that failed as children of the sample node
+            AssertionResult[] assertionResults = child.getAssertionResults();
+            int assertionIndex = leafNode.getChildCount();
+            for (AssertionResult item : assertionResults) {
+                if (item.isFailure() || item.isError()) {
+                    DefaultMutableTreeNode assertionNode = new SearchableTreeNode(item, treeModel);
+                    treeModel.insertNodeInto(assertionNode, leafNode, assertionIndex++);
+                    result = checkExpandedOrSelected(path, item,
+                            selectedObject, oldExpandedObjects, newExpandedPaths, result,
+                            assertionNode);
+                }
+            }
+        }
+        return result;
+    }
+
+    private TreePath toTreePath(java.util.List<TreeNode> newPath) {
+        return new TreePath(newPath.toArray(new TreeNode[newPath.size()]));
+    }
+
+    private TreePath toTreePath(java.util.List<TreeNode> path,
+                                DefaultMutableTreeNode extensionNode) {
+        TreeNode[] result = path.toArray(new TreeNode[path.size() + 1]);
+        result[result.length - 1] = extensionNode;
+        return new TreePath(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearData() {
+        synchronized (buffer) {
+            buffer.clear();
+            dataChanged = true;
+        }
+        resultsRender.clearData();
+        resultsObject = null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getLabelResource() {
+        return "view_results_tree_title"; // $NON-NLS-1$
+    }
+
+    /**
+     * Initialize this visualizer
+     */
+    private void init(SamplerResultTab samplerResultTab) {  // WARNING: called from ctor so must not be overridden (i.e. must be private or final)
+        log.debug("init() - pass");
+        setLayout(new BorderLayout(0, 5));
+        setBorder(makeBorder());
+
+        leftSide = createLeftPanel();
+        // Prepare the common tab
+        rightSide = new JTabbedPane();
+
+        // Create the split pane
+        mainSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftSide, rightSide);
+        mainSplit.setOneTouchExpandable(true);
+
+        JSplitPane searchAndMainSP = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
+                new SearchTreePanel(root), mainSplit);
+        searchAndMainSP.setOneTouchExpandable(true);
+        JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, makeTitlePanel(), searchAndMainSP);
+        splitPane.setOneTouchExpandable(true);
+        add(splitPane);
+
+        // init right side with first render
+        resultsRender = samplerResultTab;
+        resultsRender.setRightSide(rightSide);
+        resultsRender.init();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void valueChanged(TreeSelectionEvent e) {
+        valueChanged(e, false);
+    }
+
+    /**
+     * @param e              {@link TreeSelectionEvent}
+     * @param forceRendering boolean
+     */
+    private void valueChanged(TreeSelectionEvent e, boolean forceRendering) {
+        lastSelectionEvent = e;
+        DefaultMutableTreeNode node;
+        synchronized (this) {
+            node = (DefaultMutableTreeNode) jTree.getLastSelectedPathComponent();
+        }
+
+        if (node != null && (forceRendering || node.getUserObject() != resultsObject)) {
+            resultsObject = node.getUserObject();
+            // to restore last tab used
+            if (rightSide.getTabCount() > selectedTab) {
+                resultsRender.setLastSelectedTab(rightSide.getSelectedIndex());
+            }
+            Object userObject = node.getUserObject();
+            resultsRender.setSamplerResult(userObject);
+            resultsRender.setupTabPane(); // Processes Assertions
+            // display a SampleResult
+            if (userObject instanceof SampleResult) {
+                SampleResult sampleResult = (SampleResult) userObject;
+                if (isTextDataType(sampleResult)) {
+                    resultsRender.renderResult(sampleResult);
+                } else {
+                    byte[] responseBytes = sampleResult.getResponseData();
+                    if (responseBytes != null) {
+                        resultsRender.renderImage(sampleResult);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param sampleResult SampleResult
+     * @return true if sampleResult is text or has empty content type
+     */
+    protected static boolean isTextDataType(SampleResult sampleResult) {
+        return (SampleResult.TEXT).equals(sampleResult.getDataType())
+                || StringUtils.isEmpty(sampleResult.getDataType());
+    }
+
+    private synchronized Component createLeftPanel() {
+        SampleResult rootSampleResult = new SampleResult();
+        rootSampleResult.setSampleLabel("Root");
+        rootSampleResult.setSuccessful(true);
+        root = new SearchableTreeNode(rootSampleResult, null);
+
+        treeModel = new DefaultTreeModel(root);
+        jTree = new JTree(treeModel);
+        jTree.setCellRenderer(new ViewResultsFullVisualizerGui.ResultsNodeRenderer());
+        jTree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+        jTree.addTreeSelectionListener(this);
+        jTree.setRootVisible(false);
+        jTree.setShowsRootHandles(true);
+        JScrollPane treePane = new JScrollPane(jTree);
+        treePane.setPreferredSize(new Dimension(200, 300));
+
+        VerticalPanel leftPane = new VerticalPanel();
+        leftPane.add(treePane, BorderLayout.CENTER);
+        leftPane.add(createComboRender(), BorderLayout.NORTH);
+        autoScrollCB = new JCheckBox(JMeterUtils.getResString("view_results_autoscroll")); // $NON-NLS-1$
+        autoScrollCB.setSelected(false);
+        autoScrollCB.addItemListener(this);
+        leftPane.add(autoScrollCB, BorderLayout.SOUTH);
+        return leftPane;
+    }
+
+    /**
+     * Create the drop-down list to changer render
+     *
+     * @return List of all render (implement ResultsRender)
+     */
+    private Component createComboRender() {
+        ComboBoxModel<ResultRenderer> nodesModel = new DefaultComboBoxModel<>();
+        // drop-down list for renderer
+        selectRenderPanel = new JComboBox<>(nodesModel);
+        selectRenderPanel.setActionCommand(COMBO_CHANGE_COMMAND);
+        selectRenderPanel.addActionListener(this);
+
+        // if no results render in jmeter.properties, load Standard (default)
+        List<String> classesToAdd = Collections.<String>emptyList();
+        try {
+            classesToAdd = JMeterUtils.findClassesThatExtend(ResultRenderer.class);
+        } catch (IOException e1) {
+            // ignored
+        }
+        String textRenderer = JMeterUtils.getResString("view_results_render_text"); // $NON-NLS-1$
+        Object textObject = null;
+        Map<String, ResultRenderer> map = new HashMap<>(classesToAdd.size());
+        for (String clazz : classesToAdd) {
+            try {
+                // Instantiate render classes
+                final ResultRenderer renderer = (ResultRenderer) Class.forName(clazz).newInstance();
+                if (textRenderer.equals(renderer.toString())) {
+                    textObject = renderer;
+                }
+                renderer.setBackgroundColor(getBackground());
+                map.put(renderer.getClass().getName(), renderer);
+            } catch (Exception | NoClassDefFoundError e) { // NOSONAR See bug 60583
+                log.warn("Error loading result renderer: {}", clazz, e);
+            }
+        }
+        if (VIEWERS_ORDER.length() > 0) {
+            Arrays.stream(VIEWERS_ORDER.split(","))
+                    .map(key -> key.startsWith(".")
+                            ? "org.apache.jmeter.visualizers" + key //$NON-NLS-1$
+                            : key)
+                    .forEach(key -> {
+                        ResultRenderer renderer = map.remove(key);
+                        if (renderer != null) {
+                            selectRenderPanel.addItem(renderer);
+                        } else {
+                            log.warn(
+                                    "Missing (check renderer name) or already added (check doublon) result renderer," +
+                                            " check property 'view.results.tree.renderers_order', renderer name: '{}'",
+                                    key);
+                        }
+                    });
+        }
+        // Add remaining (plugins or missed in property)
+        map.values().forEach(renderer -> selectRenderPanel.addItem(renderer));
+        nodesModel.setSelectedItem(textObject); // preset to "Text" option
+        return selectRenderPanel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void actionPerformed(ActionEvent event) {
+        String command = event.getActionCommand();
+        if (COMBO_CHANGE_COMMAND.equals(command)) {
+            JComboBox<?> jcb = (JComboBox<?>) event.getSource();
+
+            if (jcb != null) {
+                resultsRender = (ResultRenderer) jcb.getSelectedItem();
+                if (rightSide != null) {
+                    // to restore last selected tab (better user-friendly)
+                    selectedTab = rightSide.getSelectedIndex();
+                    // Remove old right side
+                    mainSplit.remove(rightSide);
+
+                    // create and add a new right side
+                    rightSide = new JTabbedPane();
+                    mainSplit.add(rightSide);
+                    resultsRender.setRightSide(rightSide);
+                    resultsRender.setLastSelectedTab(selectedTab);
+                    log.debug("selectedTab={}", selectedTab);
+                    resultsRender.init();
+                    // To display current sampler result before change
+                    this.valueChanged(lastSelectionEvent, true);
+                }
+            }
+        }
+    }
+
+    public static String getResponseAsString(SampleResult res) {
+        String response = null;
+        if (isTextDataType(res)) {
+            // Showing large strings can be VERY costly, so we will avoid
+            // doing so if the response
+            // data is larger than 200K. TODO: instead, we could delay doing
+            // the result.setText
+            // call until the user chooses the "Response data" tab. Plus we
+            // could warn the user
+            // if this happens and revert the choice if he doesn't confirm
+            // he's ready to wait.
+            int len = res.getResponseDataAsString().length();
+            if (MAX_DISPLAY_SIZE > 0 && len > MAX_DISPLAY_SIZE) {
+                StringBuilder builder = new StringBuilder(MAX_DISPLAY_SIZE + 100);
+                builder.append(JMeterUtils.getResString("view_results_response_too_large_message")) //$NON-NLS-1$
+                        .append(len).append(" > Max: ").append(MAX_DISPLAY_SIZE)
+                        .append(", ").append(JMeterUtils.getResString("view_results_response_partial_message")) // $NON-NLS-1$
+                        .append("\n").append(res.getResponseDataAsString().substring(0, MAX_DISPLAY_SIZE)).append("\n...");
+                response = builder.toString();
+            } else {
+                response = res.getResponseDataAsString();
+            }
+        }
+        return response;
+    }
+
+    private static class ResultsNodeRenderer extends DefaultTreeCellRenderer {
+        private static final long serialVersionUID = 4159626601097711565L;
+
+        @Override
+        public Component getTreeCellRendererComponent(JTree tree, Object value,
+                                                      boolean sel, boolean expanded, boolean leaf, int row, boolean focus) {
+            super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, focus);
+            boolean failure = true;
+            Object userObject = ((DefaultMutableTreeNode) value).getUserObject();
+            if (userObject instanceof SampleResult) {
+                failure = !(((SampleResult) userObject).isSuccessful());
+            } else if (userObject instanceof AssertionResult) {
+                AssertionResult assertion = (AssertionResult) userObject;
+                failure = assertion.isError() || assertion.isFailure();
+            }
+
+            // Set the status for the node
+            if (failure) {
+                this.setForeground(Color.red);
+                this.setIcon(imageFailure);
+            } else {
+                this.setIcon(imageSuccess);
+            }
+
+            // Handle search related rendering
+            SearchableTreeNode node = (SearchableTreeNode) value;
+            if (node.isNodeHasMatched()) {
+                setBorder(RED_BORDER);
+            } else if (node.isChildrenNodesHaveMatched()) {
+                setBorder(BLUE_BORDER);
+            } else {
+                setBorder(null);
+            }
+            return this;
+        }
+    }
+
+    /**
+     * Handler for Checkbox
+     */
+    @Override
+    public void itemStateChanged(ItemEvent e) {
+        // NOOP state is held by component
+    }
+}


### PR DESCRIPTION
## Features introduced
More friendly exception prompt，Help the user correctly locate whether the exception is in the GRPCSampler or the exception on the server side.
- Reconstructing the logic of exception printing and throwing, the user can see the exception of different stages intuitively, and can easily obtain the stack information of these exceptions
- Optimize log printing. The console no longer prints grpcResponse error logs and returns them directly to SampleResult
- Remove meaningless grpcResponse stack trace, because server stack information is not thrown to the front end (GRPC specification), only parse `throwable.getMessage ()`
- To solve https://github.com/zalopay-oss/jmeter-grpc-request/pull/127 change SampleLabel, When multiple GRPCSampler exceptions occur, the exception ownership relationship cannot be confirmed.

```java
// The wrong/Be changed
sampleResult.setSampleLabel("Error When Initiated gRPC");
// correct/previous
sampleResult.setSampleLabel(getName());
```

## Resolve remaining exception prompt issues
### Related issues
https://github.com/zalopay-oss/jmeter-grpc-request/issues/96
https://github.com/zalopay-oss/jmeter-grpc-request/issues/114
https://github.com/zalopay-oss/jmeter-grpc-request/issues/104
https://github.com/zalopay-oss/jmeter-grpc-request/issues/97
https://github.com/zalopay-oss/jmeter-grpc-request/issues/105
https://github.com/zalopay-oss/jmeter-grpc-request/issues/113

### Related pr
https://github.com/zalopay-oss/jmeter-grpc-request/pull/99
https://github.com/zalopay-oss/jmeter-grpc-request/pull/127

### The other study
When PR is merged, associated issues will not be closed. Should they be closed automatically

## More instructions
Sorry, this is a PR that has been delayed for a long time. Due to testing in offline development, I forgot to submit the PR.